### PR TITLE
GxAbstractEntityList default ContextMenu

### DIFF
--- a/gx/gx-flow/src/main/java/io/graphenee/vaadin/flow/event/TRDelayMenuClickListener.java
+++ b/gx/gx-flow/src/main/java/io/graphenee/vaadin/flow/event/TRDelayMenuClickListener.java
@@ -1,0 +1,46 @@
+package io.graphenee.vaadin.flow.event;
+
+import java.util.concurrent.Executors;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.grid.contextmenu.GridContextMenu;
+import com.vaadin.flow.component.grid.contextmenu.GridContextMenu.GridContextMenuItemClickEvent;
+
+public abstract class TRDelayMenuClickListener<T, C extends Component> implements ComponentEventListener<GridContextMenu.GridContextMenuItemClickEvent<T>> {
+
+    private static final long serialVersionUID = 1L;
+
+    private long sleepDuration = 1000L;
+    volatile boolean isFired = false;
+
+    @Override
+    public void onComponentEvent(GridContextMenuItemClickEvent<T> event) {
+        if (!isFired) {
+            synchronized (this) {
+                if (!isFired) {
+                    isFired = true;
+                    try {
+                        onClick(event);
+                    } finally {
+                        Executors.newSingleThreadExecutor().execute(() -> {
+                            try {
+                                Thread.sleep(sleepDuration);
+                            } catch (InterruptedException e) {
+                            } finally {
+                                isFired = false;
+                            }
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    public TRDelayMenuClickListener<T, C> withSleepDuration(long sleepDuration) {
+        this.sleepDuration = sleepDuration;
+        return this;
+    }
+
+    public abstract void onClick(GridContextMenuItemClickEvent<T> event);
+}


### PR DESCRIPTION
Default ContextMenu added in GxAbstractEntityList with **Add**, **Edit** and **Delete** actions. 
Child components can override **decorateContextMenu(GridContextMenu<Process> contextMenu)** to add custom ContextMenu Items.
