### PR TITLE
Show user friendly message if failed to delete documentExplorerItem

### DIFF
--- a/gx/gx-core-flow/src/main/java/io/graphenee/core/flow/documents/GxDocumentExplorer.java
+++ b/gx/gx-core-flow/src/main/java/io/graphenee/core/flow/documents/GxDocumentExplorer.java
@@ -12,8 +12,10 @@ import java.util.concurrent.Future;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
@@ -331,7 +333,16 @@ public class GxDocumentExplorer extends GxAbstractEntityTreeList<GxDocumentExplo
 
 	@Override
 	protected void onDelete(Collection<GxDocumentExplorerItem> entities) {
-		documentService.deleteExplorerItem(new ArrayList<>(entities));
+		try {
+            documentService.deleteExplorerItem(new ArrayList<>(entities));
+        } catch (DataIntegrityViolationException ex) {
+            if (StringUtils.isNotBlank(ex.getMessage()) && ex.getMessage().contains("violates foreign key constraint")) {
+                GxNotification.error("One or more selected record(s) are in use and can not be deleted.");
+            } else {
+                GxNotification.error("Failed to delete one or more selected record(s).");
+            }
+        }
+
 	}
 
 	@Override


### PR DESCRIPTION
When using document explorer component in client application if failed to delete a document or folder because of **DataIntegrityViolationException** it shows long system generated message which is not user friendly.

Added a user friendly message when failed to delete document or folder

**Error Message Before Fix**
![del error](https://github.com/ijazfx/graphenee/assets/71253707/1f6a9bd7-9f93-4f06-a661-e8f3b6045bef)

**Error Message After Fix**
![Screenshot 2024-01-31 at 5 36 49 PM](https://github.com/ijazfx/graphenee/assets/71253707/0be3fd1a-c11c-46ab-840d-ee9bc210c0a5)
![Screenshot 2024-01-31 at 5 41 52 PM](https://github.com/ijazfx/graphenee/assets/71253707/c4346a7c-9ec4-460b-b89c-3437a411d65a)
